### PR TITLE
bugFix：在 Android O 以下悬浮窗会像 Toast 一样自己消失

### DIFF
--- a/fpsviewer/src/main/java/com/silencedut/fpsviewer/datashow/DisplayView.java
+++ b/fpsviewer/src/main/java/com/silencedut/fpsviewer/datashow/DisplayView.java
@@ -107,7 +107,7 @@ public class DisplayView implements IDisplayFps, View.OnClickListener, View.OnTo
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             mLayoutParams.type = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
         } else {
-            mLayoutParams.type = WindowManager.LayoutParams.TYPE_TOAST;
+            mLayoutParams.type = WindowManager.LayoutParams.TYPE_PHONE;
         }
 
         mLayoutParams.flags = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE | WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL |


### PR DESCRIPTION
在 Android O 以下的悬浮窗类型是 Toast，具有 Toast 类似的特性，会自己消失，换成 phone 类型